### PR TITLE
build: remove unused TS config file

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig-base.json",
-  "files": [],
-  "include": [],
-  "references": [{ "path": "src/" }]
-}


### PR DESCRIPTION
This file is not necessary anymore since all packages have been moved to the monorepo structure.