### PR TITLE
Add base-path parameter to Coveralls

### DIFF
--- a/.github/workflows/main-test.yml
+++ b/.github/workflows/main-test.yml
@@ -84,7 +84,8 @@ jobs:
           # We collect all coverages in parallel
           parallel: true
           flag-name: ${{ matrix.package }}
-          path-to-lcov: ${{ github.workspace }}/${{ matrix.package }}/coverage/lcov.info
+          base-path: ${{ matrix.package }}/
+          path-to-lcov: ${{ matrix.package }}/coverage/lcov.info
 
   # Indicate sending coverage to Coveralls is finished
   coverage-finished:

--- a/.github/workflows/main-test.yml
+++ b/.github/workflows/main-test.yml
@@ -67,6 +67,9 @@ jobs:
           - plugins/plugin-core-sfuzz
 
     steps:
+      # Cloning
+      - uses: actions/checkout@v3
+
       # Download test results
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -9,6 +9,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+  
+env:
+  NODE_COVERALLS_DEBUG: 1
+  COVERALLS_DEBUG: true
 
 jobs:
   test:
@@ -119,7 +123,7 @@ jobs:
           # We collect all coverages in parallel
           parallel: true
           flag-name: ${{ matrix.package }}
-          base-path: ${{ matrix.package }}
+          base-path: ${{ github.workspace }}/${{ matrix.package }}/
           path-to-lcov: ${{ github.workspace }}/${{ matrix.package }}/coverage/lcov.info
 
   # Indicate sending coverage to Coveralls is finished

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -123,8 +123,8 @@ jobs:
           # We collect all coverages in parallel
           parallel: true
           flag-name: ${{ matrix.package }}
-          base-path: ${{ github.workspace }}/${{ matrix.package }}/
-          path-to-lcov: ${{ github.workspace }}/${{ matrix.package }}/coverage/lcov.info
+          base-path: ${{ matrix.package }}/
+          path-to-lcov: ${{ matrix.package }}/coverage/lcov.info
 
   # Indicate sending coverage to Coveralls is finished
   coverage-finished:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -109,6 +109,9 @@ jobs:
           - plugins/plugin-core-sfuzz
 
     steps:
+      # Cloning
+      - uses: actions/checkout@v3
+      
       # Download test results
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -9,10 +9,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
-env:
-  NODE_COVERALLS_DEBUG: 1
-  COVERALLS_DEBUG: true
 
 jobs:
   test:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -119,6 +119,7 @@ jobs:
           # We collect all coverages in parallel
           parallel: true
           flag-name: ${{ matrix.package }}
+          base-path: ${{ matrix.package }}
           path-to-lcov: ${{ github.workspace }}/${{ matrix.package }}/coverage/lcov.info
 
   # Indicate sending coverage to Coveralls is finished


### PR DESCRIPTION
Coveralls is having trouble parsing the LCOV files generated during the test and coverage scripts. According to this [issue](https://github.com/lemurheavy/coveralls-public/issues/1593#issuecomment-1042117714), the base-path is necessary next to the path to LCOV to make sense of the data in the LCOV file. This was unclear from the documentation