### PR TITLE
Add main branch workflows

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -1,7 +1,9 @@
-name: pr-quality
+name: main-build
 
 on:
-  pull_request:
+  push:
+    branches:
+      - main
     paths-ignore:
       - "docs/"
       - "**.md"
@@ -11,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  quality:
-    name: Verify Code Quality
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       # Cloning
@@ -32,10 +34,6 @@ jobs:
       - name: Core - Install Dependencies
         run: npm ci
 
-      # Formatting
-      - name: Core - Run Formatter
-        run: npm run format:check
-
-      # Linting
-      - name: Core - Run Linter
-        run: npm run lint
+      # Building
+      - name: Core - Build
+        run: npm run build

--- a/.github/workflows/main-quality.yml
+++ b/.github/workflows/main-quality.yml
@@ -1,7 +1,9 @@
-name: pr-quality
+name: main-quality
 
 on:
-  pull_request:
+  push:
+    branches:
+      - main
     paths-ignore:
       - "docs/"
       - "**.md"

--- a/.github/workflows/main-test.yml
+++ b/.github/workflows/main-test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "docs/"
+      - "**.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,15 +16,12 @@ jobs:
   test:
     name: Coverage - Calculation
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: "."
     steps:
       # Cloning
       - uses: actions/checkout@v3
 
       # Setup and Caching
-      - name: Use Node.js
+      - name: Use latest Node.js LTS version
         uses: actions/setup-node@v3
         with:
           node-version: lts/*

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,9 +14,6 @@ jobs:
   build:
     name: Build
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: "."
     strategy:
       # Stop remaining runs when a build fails that is not experimental
       fail-fast: true

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -14,9 +14,6 @@ jobs:
   test:
     name: Test
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        working-directory: "."
     strategy:
       # Stop remaining runs when a build fails that is not experimental
       fail-fast: true

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           # Use CI token that can override branch protection
           token: ${{ secrets.SYNTEST_CI }}
+          fetch-depth: 0
 
       # Setup, Caching, and .npmrc file to publish to npm
       - name: Use latest Node.js LTS version
@@ -51,14 +52,19 @@ jobs:
       - name: Core - Build
         run: npm run build
 
-      # Versioning and publishing
-      - name: "Core - Version and publish"
+      # Versioning
+      - name: "Core - Version"
         env:
           GH_TOKEN: ${{ secrets.SYNTEST_CI }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
         run: |
           npx lerna version --conventional-commits --conventional-prerelease --changelog-preset conventionalcommits --preid beta --no-changelog --no-git-tag-version --yes --loglevel silly
           git add .
           git commit -m "chore(release): release beta version"
           git push
-          npx lerna publish from-package --dist-tag beta --yes --loglevel silly
+      
+      # Publishing
+      - name: "Core - Publish"
+        env:
+          GH_TOKEN: ${{ secrets.SYNTEST_CI }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+        run: npx lerna publish from-package --dist-tag beta --yes --loglevel silly

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.SYNTEST_CI }}
 
       # Setup, Caching, and .npmrc file to publish to npm
-      - name: Use Node.js
+      - name: Use latest Node.js LTS version
         uses: actions/setup-node@v3
         with:
           node-version: lts/*

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ jobs:
           token: ${{ secrets.SYNTEST_CI }}
           
       # Setup, Caching, and .npmrc file to publish to npm
-      - name: Use Node.js
+      - name: Use latest Node.js LTS version
         uses: actions/setup-node@v3
         with:
           node-version: lts/*

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.SYNTEST_CI }}
+          fetch-depth: 0
           
       # Setup, Caching, and .npmrc file to publish to npm
       - name: Use latest Node.js LTS version

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.SYNTEST_CI }}
 
       # Setup and Caching
-      - name: Use Node.js
+      - name: Use latest Node.js LTS version
         uses: actions/setup-node@v3
         with:
           node-version: lts/*

--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.SYNTEST_CI }}
+          fetch-depth: 0
 
       # Setup and Caching
       - name: Use latest Node.js LTS version


### PR DESCRIPTION
Previously, we only had build and quality workflows for PRs. To allow us to show build and quality status badges on the README, we need to also run these workflows on the main branch.


Closes #246 
Closes #243 