### PR TITLE
Patch cfg factory

### DIFF
--- a/libraries/cfg-core/lib/ControlFlowGraphFactory.ts
+++ b/libraries/cfg-core/lib/ControlFlowGraphFactory.ts
@@ -18,6 +18,6 @@
 
 import { ControlFlowProgram } from "./ControlFlowProgram";
 
-export interface ControlFlowGraphFactory {
-  convertAST<S>(AST: S): ControlFlowProgram<S>;
+export interface ControlFlowGraphFactory<S> {
+  convertAST(filePath: string, AST: S): ControlFlowProgram<S>;
 }


### PR DESCRIPTION
The generic variable S was misplaced on the function instead of the class; this makes it hard to change what S exactly is.

The function also requires a filePath since the CFG factory will make use of the babel visitor in the javascript implementation which also requires a filePath to be specified.