### PR TITLE
Remove concurrent build canceling for main branch

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -8,10 +8,6 @@ on:
       - "docs/"
       - "**.md"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     name: Build

--- a/.github/workflows/main-quality.yml
+++ b/.github/workflows/main-quality.yml
@@ -8,10 +8,6 @@ on:
       - "docs/"
       - "**.md"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   quality:
     name: Verify Code Quality

--- a/.github/workflows/main-test.yml
+++ b/.github/workflows/main-test.yml
@@ -8,10 +8,6 @@ on:
       - "docs/"
       - "**.md"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     name: Coverage - Calculation


### PR DESCRIPTION
By canceling concurrent builds for the main branch, the status badges and the coverage statistics will show a failed build. This was done initially for the PR builds as there, it would not make sense to build commits rapidly done after each other since this is the development stage.