### PR TITLE
Secondary objectives arg was not matching

### DIFF
--- a/tools/base-language/lib/Configuration.ts
+++ b/tools/base-language/lib/Configuration.ts
@@ -206,7 +206,7 @@ export class Configuration {
         hidden: false,
         type: "string",
       },
-      "secondary-objective": {
+      "secondary-objectives": {
         alias: [],
         default: [],
         choices: [],


### PR DESCRIPTION
Search algorithms were crashing if no secondary objective was defined. This happened by a name mismatch in the Yargs configuration