### PR TITLE
Fix branch distance NaN bug

### DIFF
--- a/libraries/search/lib/Encoding.ts
+++ b/libraries/search/lib/Encoding.ts
@@ -20,6 +20,7 @@ import { Decoder } from "./Decoder";
 import { EncodingSampler } from "./EncodingSampler";
 import { ExecutionResult } from "./ExecutionResult";
 import { ObjectiveFunction } from "./objective/ObjectiveFunction";
+import { shouldNeverHappen } from "./util/diagnostics";
 import { prng } from "./util/prng";
 
 /**
@@ -122,13 +123,19 @@ export abstract class Encoding {
    * @param objectiveFunction The objective.
    */
   getDistance(objectiveFunction: ObjectiveFunction<Encoding>): number {
-    if (this._objectives.has(objectiveFunction))
+    if (this._objectives.has(objectiveFunction)) {
+      if (Number.isNaN(this._objectives.get(objectiveFunction))) {
+        throw new TypeError(shouldNeverHappen("Encoding"));
+      }
       return this._objectives.get(objectiveFunction);
-    else {
+    } else {
       // this part is needed for DynaMOSA
       // it may happen that the test was created when the objective in input was not part of the search yet
       // with this code, we keep the objective values up to date
       const distance = objectiveFunction.calculateDistance(this);
+      if (Number.isNaN(distance)) {
+        throw new TypeError(shouldNeverHappen("Encoding"));
+      }
       this._objectives.set(objectiveFunction, distance);
       return distance;
     }
@@ -144,6 +151,9 @@ export abstract class Encoding {
     objectiveFunction: ObjectiveFunction<Encoding>,
     distance: number
   ): void {
+    if (Number.isNaN(distance)) {
+      throw new TypeError(shouldNeverHappen("Encoding"));
+    }
     this._objectives.set(objectiveFunction, distance);
   }
 

--- a/libraries/search/lib/objective/BranchObjectiveFunction.ts
+++ b/libraries/search/lib/objective/BranchObjectiveFunction.ts
@@ -139,12 +139,32 @@ export class BranchObjectiveFunction<
       throw new Error(shouldNeverHappen("BranchObjectiveFunction"));
     }
 
-    const branchDistance = this.branchDistance.calculate(
+    let branchDistance = this.branchDistance.calculate(
       closestCoveredBranchTrace.condition_ast,
       closestCoveredBranchTrace.condition,
       closestCoveredBranchTrace.variables,
       trueOrFalse
     );
+
+    if (
+      !(typeof branchDistance === "number" && Number.isFinite(branchDistance))
+    ) {
+      // this is a dirty hack to prevent wrong branch distance numbers
+      // in the future we need to simply fix the branch distance calculation and remove this
+      branchDistance = 0.999;
+    }
+
+    if (Number.isNaN(approachLevel)) {
+      throw new TypeError(shouldNeverHappen("ObjectiveManager"));
+    }
+
+    if (Number.isNaN(branchDistance)) {
+      throw new TypeError(shouldNeverHappen("ObjectiveManager"));
+    }
+
+    if (Number.isNaN(approachLevel + branchDistance)) {
+      throw new TypeError(shouldNeverHappen("ObjectiveManager"));
+    }
 
     // add the distances
     return approachLevel + branchDistance;

--- a/libraries/search/lib/objective/managers/ObjectiveManager.ts
+++ b/libraries/search/lib/objective/managers/ObjectiveManager.ts
@@ -26,6 +26,7 @@ import { Encoding } from "../../Encoding";
 import { EncodingRunner } from "../../EncodingRunner";
 import { SearchSubject } from "../../SearchSubject";
 import { TerminationManager } from "../../termination/TerminationManager";
+import { shouldNeverHappen } from "../../util/diagnostics";
 import { ExceptionObjectiveFunction } from "../ExceptionObjectiveFunction";
 import { ObjectiveFunction } from "../ObjectiveFunction";
 import { SecondaryObjectiveComparator } from "../secondary/SecondaryObjectiveComparator";
@@ -197,6 +198,9 @@ export abstract class ObjectiveManager<T extends Encoding> {
     for (const objectiveFunction of this._currentObjectives) {
       // Calculate and store the distance
       const distance = objectiveFunction.calculateDistance(encoding);
+      if (Number.isNaN(distance)) {
+        throw new TypeError(shouldNeverHappen("ObjectiveManager"));
+      }
       encoding.setDistance(objectiveFunction, distance);
 
       // When the objective is covered, update the objectives and the archive


### PR DESCRIPTION
The branch distance became NaN because the branch distance calculation contains a bug currently.
This PR adds several guards to check for this behavior and implements a temporary "hack" as a workaround to the problem.
This "hack" will be removed at a later point in time.