### PR TITLE
Improve archive

### DIFF
--- a/libraries/search/lib/Archive.ts
+++ b/libraries/search/lib/Archive.ts
@@ -92,19 +92,19 @@ export class Archive<T extends Encoding> {
     encoding: T,
     keepOld: boolean
   ): void {
-    const old_encoding = this._map.get(objectiveFunction);
+    const oldEncoding = this._map.get(objectiveFunction);
 
     // Remove the old encoding from the uses map
-    if (old_encoding && old_encoding !== encoding) {
-      const uses = this._uses.get(old_encoding);
+    if (oldEncoding && oldEncoding !== encoding) {
+      const uses = this._uses.get(oldEncoding);
       uses.splice(uses.indexOf(objectiveFunction), 1);
       if (uses.length === 0 && !keepOld) {
-        this._uses.delete(old_encoding);
+        this._uses.delete(oldEncoding);
       }
     }
 
     // Do not update if the encoding is already assigned to the objective function
-    if (old_encoding && old_encoding === encoding) {
+    if (oldEncoding && oldEncoding === encoding) {
       Archive.LOGGER.debug("encoding already assigned to objective function");
       throw new Error(
         shouldNeverHappen("encoding already assigned to objective function")
@@ -115,11 +115,11 @@ export class Archive<T extends Encoding> {
     this._map.set(objectiveFunction, encoding);
 
     // Add the encoding to the uses map
-    if (this._uses.has(encoding)) {
-      this._uses.get(encoding).push(objectiveFunction);
-    } else {
-      this._uses.set(encoding, [objectiveFunction]);
+    if (!this._uses.has(encoding)) {
+      this._uses.set(encoding, []);
     }
+
+    this._uses.get(encoding).push(objectiveFunction);
   }
 
   /**

--- a/libraries/search/lib/objective/managers/ObjectiveManager.ts
+++ b/libraries/search/lib/objective/managers/ObjectiveManager.ts
@@ -38,6 +38,7 @@ import { SecondaryObjectiveComparator } from "../secondary/SecondaryObjectiveCom
  */
 export abstract class ObjectiveManager<T extends Encoding> {
   protected static LOGGER: Logger;
+
   /**
    * Archive of covered objectives with the fittest encoding for that objective.
    * @protected
@@ -123,7 +124,7 @@ export abstract class ObjectiveManager<T extends Encoding> {
     encoding: T
   ) {
     ObjectiveManager.LOGGER.debug("updating archive");
-    if (!this._archive.has(objectiveFunction)) {
+    if (!this._archive.hasObjective(objectiveFunction)) {
       ObjectiveManager.LOGGER.debug(
         `new objective covered: ${objectiveFunction.getIdentifier()}`
       );


### PR DESCRIPTION
The current implementation of the archive only stores encodings that are the fittest for an objective. By also storing the reverse mapping, it allows the archive to store encodings that are not the fittest for any objective but do generate coverage.