### PR TITLE
Patch approach level calculation

### DIFF
--- a/libraries/search/lib/objective/heuristics/ApproachLevel.ts
+++ b/libraries/search/lib/objective/heuristics/ApproachLevel.ts
@@ -32,7 +32,7 @@ export class ApproachLevel {
   } {
     // Construct map with key as id covered and value as datapoint that covers that id
     const idsTraceMap: Map<string, Datapoint> = new Map(
-      traces.map((trace) => [trace.id, trace])
+      traces.filter((trace) => trace.hits > 0).map((trace) => [trace.id, trace])
     );
 
     // Construct set of all covered ids


### PR DESCRIPTION
The approach level was now considering every trace whether it was covered or not. 

Impact: this caused the approach level to always be zero.

We now filter out the traces that don't have any hits.