### PR TITLE
Add relative module finding

### DIFF
--- a/libraries/module/lib/ModuleManager.ts
+++ b/libraries/module/lib/ModuleManager.ts
@@ -22,6 +22,7 @@ import { ItemizationItem, UserInterface } from "@syntest/cli-graphics";
 import { getLogger, Logger } from "@syntest/logging";
 import { Metric, MetricManager, MetricOptions } from "@syntest/metric";
 import { StorageManager } from "@syntest/storage";
+import { findUpSync } from "find-up";
 import globalModules = require("global-modules");
 import Yargs = require("yargs");
 
@@ -237,9 +238,11 @@ export class ModuleManager {
       }
     } else {
       // It is a npm package
-      modulePath = path.resolve(path.join("node_modules", module));
+      modulePath = findUpSync(path.join("node_modules", module), {
+        type: "directory",
+      });
 
-      if (!existsSync(modulePath)) {
+      if (modulePath === undefined) {
         // it is not locally installed lets try global
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         modulePath = path.resolve(path.join(globalModules, module));

--- a/libraries/module/package.json
+++ b/libraries/module/package.json
@@ -50,6 +50,7 @@
     "@syntest/logging": "*",
     "@syntest/metric": "^0.1.0-beta.6",
     "@syntest/storage": "^0.1.0-beta.0",
+    "find-up": "^6.3.0",
     "global-modules": "2.0.0",
     "yargs": "^17.7.1"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,11 +152,88 @@
         "@syntest/logging": "*",
         "@syntest/metric": "^0.1.0-beta.6",
         "@syntest/storage": "^0.1.0-beta.0",
+        "find-up": "^6.3.0",
         "global-modules": "2.0.0",
         "yargs": "^17.7.1"
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "libraries/module/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "libraries/module/node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "libraries/module/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "libraries/module/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "libraries/module/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "libraries/module/node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "libraries/search": {


### PR DESCRIPTION
Currently, the tool can only be run in the root folder if modules are loaded that are installed locally. This happens as the program makes the assumption that the `node_modules` folder can be found in the current working directory. However, it can be quite common to run the tool from a sub-directory.

This PR adds the ability to do upwards-looking searches for particular files or directories

Resolves: #239 

The logic for the upwards-looking functionality could possibly be added to the storage module. However, since this module mostly focusses on the storage of the output of the tool and not the input. I am not sure if this is a good match