### PR TITLE
Add concept of age to the encoding

### DIFF
--- a/libraries/search/lib/Encoding.ts
+++ b/libraries/search/lib/Encoding.ts
@@ -34,6 +34,7 @@ export abstract class Encoding {
   protected _id: string;
   protected _assertions: Map<string, string>;
   protected _metaComments: string[];
+  protected _age: number;
 
   /**
    * Mapping from objective to their distance values for this test case.
@@ -81,6 +82,14 @@ export abstract class Encoding {
 
   get id(): string {
     return this._id;
+  }
+
+  get age(): number {
+    return this._age;
+  }
+
+  set age(value: number) {
+    this._age = value;
   }
 
   get assertions(): Map<string, string> {


### PR DESCRIPTION
By tracking how long an encoding has been around, it allows us to determine when an encoding was created, when it was added to the archive, how long it has been part of the fittest selection, etc