### PR TITLE
Remove evaluation argument from budgets

### DIFF
--- a/libraries/search/lib/budget/BudgetListener.ts
+++ b/libraries/search/lib/budget/BudgetListener.ts
@@ -56,8 +56,6 @@ export interface BudgetListener<T extends Encoding> {
 
   /**
    * Signal evaluation happened.
-   *
-   * @param encoding The encoding that was evaluated
    */
-  evaluation(encoding: T): void;
+  evaluation(): void;
 }

--- a/libraries/search/lib/budget/BudgetManager.ts
+++ b/libraries/search/lib/budget/BudgetManager.ts
@@ -92,9 +92,7 @@ export class BudgetManager<T extends Encoding> implements BudgetListener<T> {
    * @param budget The budget to remove
    */
   removeBudget(budget: Budget<T>): this {
-    const name = [...this._budgets.entries()].find(
-      ([, b]) => b === budget
-    )[0];
+    const name = [...this._budgets.entries()].find(([, b]) => b === budget)[0];
     this._budgets.delete(name);
     return this;
   }

--- a/libraries/search/lib/budget/BudgetManager.ts
+++ b/libraries/search/lib/budget/BudgetManager.ts
@@ -74,7 +74,7 @@ export class BudgetManager<T extends Encoding> implements BudgetListener<T> {
    *
    * @param budget The budget to add
    */
-  addBudget(name: BudgetType, budget: Budget<T>): BudgetManager<T> {
+  addBudget(name: BudgetType, budget: Budget<T>): this {
     this._budgets.set(name, budget);
     return this;
   }
@@ -91,10 +91,10 @@ export class BudgetManager<T extends Encoding> implements BudgetListener<T> {
    *
    * @param budget The budget to remove
    */
-  removeBudget(budget: Budget<T>): BudgetManager<T> {
+  removeBudget(budget: Budget<T>): this {
     const name = [...this._budgets.entries()].find(
       ([, b]) => b === budget
-    )?.[0];
+    )[0];
     this._budgets.delete(name);
     return this;
   }
@@ -138,7 +138,7 @@ export class BudgetManager<T extends Encoding> implements BudgetListener<T> {
   /**
    * @inheritDoc
    */
-  evaluation(encoding: T): void {
-    for (const budget of this._budgets.values()) budget.evaluation(encoding);
+  evaluation(): void {
+    for (const budget of this._budgets.values()) budget.evaluation();
   }
 }

--- a/libraries/search/lib/objective/managers/ObjectiveManager.ts
+++ b/libraries/search/lib/objective/managers/ObjectiveManager.ts
@@ -175,7 +175,7 @@ export abstract class ObjectiveManager<T extends Encoding> {
     const result = await this._runner.execute(this._subject, encoding);
 
     // TODO: Use events for this so we can elimate the dependency on the budget manager
-    budgetManager.evaluation(encoding);
+    budgetManager.evaluation();
 
     // Store the execution result in the encoding
     encoding.setExecutionResult(result);


### PR DESCRIPTION
The evaluation argument is never used in the budgets and therefore can be removed. This allows us to clean up the objective manager a bit.

Originally, we wanted to remove all arguments to the budgets. However, as it turns out the stagnation budget requires the search algorithm to determine if any progress was made