### PR TITLE
Make seeded prng global

### DIFF
--- a/libraries/prng/lib/prng.ts
+++ b/libraries/prng/lib/prng.ts
@@ -33,7 +33,7 @@ export function initializePseudoRandomNumberGenerator(seed: string) {
     throw new Error(singletonAlreadySet("PseudoRandomNumberGenerator"));
   }
 
-  random = seedrandom(seed);
+  random = seedrandom(seed, { global: true });
 }
 
 function generator() {


### PR DESCRIPTION
Currently, the seeded PRNG is only used internally by us. However, the library we use for this has an option to overwrite Math.random(). This would allow us to catch any random call that we might have missed in our code but also calls to Math.random() in our dependencies.

We need to be careful though that this does not have unwanted side affects on our dependencies, but this should not be the case.