### PR TITLE
Remove constant pool configuration from core

### DIFF
--- a/tools/base-language/lib/Configuration.ts
+++ b/tools/base-language/lib/Configuration.ts
@@ -68,14 +68,12 @@ export type PostProcessingOptions = {
 export type SamplingOptions = {
   maxDepth: number;
   maxActionStatements: number;
-  constantPool: boolean;
   exploreIllegalValues: boolean;
   resampleGeneProbability: number;
   deltaMutationProbability: number;
   sampleExistingValueProbability: number;
   multiPointCrossoverProbability: number;
   crossoverProbability: number;
-  constantPoolProbability: number;
   sampleFunctionOutputAsArgument: number;
   stringAlphabet: string;
   stringMaxLength: number;
@@ -322,14 +320,6 @@ export class Configuration {
         hidden: false,
         type: "number",
       },
-      "constant-pool": {
-        alias: [],
-        default: false,
-        description: "Enable constant pool.",
-        group: OptionGroups.Sampling,
-        hidden: false,
-        type: "boolean",
-      },
 
       // mutation settings
       "explore-illegal-values": {
@@ -380,15 +370,6 @@ export class Configuration {
         alias: [],
         default: 0.5,
         description: "Probability crossover happens at a certain branch point.",
-        group: OptionGroups.Sampling,
-        hidden: false,
-        type: "number",
-      },
-      "constant-pool-probability": {
-        alias: [],
-        default: 0.5,
-        description:
-          "Probability to sample from the constant pool instead creating random values",
         group: OptionGroups.Sampling,
         hidden: false,
         type: "number",

--- a/tools/base-language/lib/Launcher.ts
+++ b/tools/base-language/lib/Launcher.ts
@@ -158,10 +158,6 @@ export abstract class Launcher {
       `${this.arguments_.maxActionStatements.toString()}`
     );
     this.metricManager.recordProperty(
-      PropertyName.CONSTANT_POOL_ENABLED,
-      `${this.arguments_.constantPool.toString()}`
-    );
-    this.metricManager.recordProperty(
       PropertyName.EXPLORE_ILLEGAL_VALUES,
       `${this.arguments_.exploreIllegalValues.toString()}`
     );
@@ -184,10 +180,6 @@ export abstract class Launcher {
     this.metricManager.recordProperty(
       PropertyName.CROSSOVER_PROBABILITY,
       `${this.arguments_.crossoverProbability.toString()}`
-    );
-    this.metricManager.recordProperty(
-      PropertyName.CONSTANT_POOL_PROBABILITY,
-      `${this.arguments_.constantPoolProbability.toString()}`
     );
     this.metricManager.recordProperty(
       PropertyName.SAMPLE_FUNCTION_OUTPUT_AS_ARGUMENT,


### PR DESCRIPTION
Since the constant pool is specific to the different languages. We have moved this configuration over to those packages.