### PR TITLE
Enforce gracefull exit

### DIFF
--- a/tools/base-language/lib/Launcher.ts
+++ b/tools/base-language/lib/Launcher.ts
@@ -68,6 +68,7 @@ export abstract class Launcher {
     } catch (error) {
       console.log(error);
       console.trace(error);
+      await this.exit();
     }
   }
 


### PR DESCRIPTION
Currently, when an error has been thrown the exit function of the launcher is not called.
To ensure everything is properly cleaned up it is important that the exit function is actually called when an error is thrown.