### PR TITLE
Do not calculate approach level when there are no traces

### DIFF
--- a/libraries/search/lib/objective/BranchObjectiveFunction.ts
+++ b/libraries/search/lib/objective/BranchObjectiveFunction.ts
@@ -56,7 +56,10 @@ export class BranchObjectiveFunction<
   calculateDistance(encoding: T): number {
     const executionResult = encoding.getExecutionResult();
 
-    if (executionResult === undefined) {
+    if (
+      executionResult === undefined ||
+      executionResult.getTraces().length === 0
+    ) {
       return Number.MAX_VALUE;
     }
 


### PR DESCRIPTION
Currently, when there are no execution traces the objective functions make various calculations that are not necessary as these will never be needed. This PR makes is so that the whole calculation is short-circuited when there are no traces.