### PR TITLE
Store covered data at end of search

### DIFF
--- a/libraries/metric/lib/Metric.ts
+++ b/libraries/metric/lib/Metric.ts
@@ -15,33 +15,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { SeriesUnit } from "./PropertyTypes";
+
 export type Metric =
   | PropertyMetric
   | DistributionMetric
   | SeriesMetric
-  | SeriesDistributionMetric;
+  | SeriesDistributionMetric
+  | SeriesMeasurementMetric;
 
 export interface PropertyMetric {
   type: MetricType.PROPERTY;
-  property: string;
+  name: string;
 }
 
 export interface DistributionMetric {
   type: MetricType.DISTRIBUTION;
-  distributionName: string;
+  name: string;
 }
 
 export interface SeriesMetric {
   type: MetricType.SERIES;
-  seriesName: string;
-  seriesType: SeriesType;
+  name: string;
+  seriesUnit: SeriesUnit;
 }
 
 export interface SeriesDistributionMetric {
   type: MetricType.SERIES_DISTRUBUTION;
-  distributionName: string;
-  seriesName: string;
-  seriesType: SeriesType;
+  name: string;
+  seriesUnit: SeriesUnit;
+}
+
+export interface SeriesMeasurementMetric {
+  type: MetricType.SERIES_MEASUREMENT;
+  name: string;
+  seriesUnit: SeriesUnit;
 }
 
 export enum MetricType {
@@ -49,11 +57,5 @@ export enum MetricType {
   DISTRIBUTION = "distribution",
   SERIES = "series",
   SERIES_DISTRUBUTION = "series-distribution",
-}
-
-export enum SeriesType {
-  SEARCH_TIME = "search-time",
-  TOTAL_TIME = "total-time",
-  ITERATION = "iteration",
-  EVALUATION = "evaluation",
+  SERIES_MEASUREMENT = "series-measurement",
 }

--- a/libraries/metric/lib/PropertyTypes.ts
+++ b/libraries/metric/lib/PropertyTypes.ts
@@ -15,12 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export type PropertyName = string;
-export type Property = string;
+export type Name = string;
 
-export type DistributionName = string;
 export type Distribution = number[];
 
-export type SeriesName = string;
-export type SeriesTyping = string;
+export enum SeriesUnit {
+  SEARCH_TIME = "search-time",
+  TOTAL_TIME = "total-time",
+  EVALUATION = "evaluation",
+  ITERATION = "iteration",
+}
 export type Series<T> = Map<number, T>;
+
+export type PropertiesMap<T> = Map<Name, T>;
+export type DistributionsMap = Map<Name, Distribution>;
+export type SeriesMap<T> = Map<Name, Map<SeriesUnit, Series<T>>>;

--- a/libraries/metric/lib/util/diagnostics.ts
+++ b/libraries/metric/lib/util/diagnostics.ts
@@ -34,19 +34,13 @@ export const seriesTypeNotRegistered = (
 ) =>
   `Cannot record series! Metric '${seriesName}.${seriesType}' is not registered by any module!`;
 
-export const seriesDistributionNotRegistered = (distribution: string) =>
-  `Cannot record series distribution! Metric '${distribution}' is not registered by any module!`;
-export const seriesDistributionSeriesNotRegistered = (
-  distribution: string,
-  seriesName: string
-) =>
-  `Cannot record series distribution! Metric '${distribution}.${seriesName}' is not registered by any module!`;
+export const seriesDistributionNotRegistered = (name: string) =>
+  `Cannot record series distribution! Metric '${name}' is not registered by any module!`;
 export const seriesDistributionTypeNotRegistered = (
-  distribution: string,
-  seriesName: string,
+  name: string,
   seriesType: string
 ) =>
-  `Cannot record series distribution! Metric '${distribution}.${seriesName}.${seriesType}' is not registered by any module!`;
+  `Cannot record series distribution! Metric '${name}.${seriesType}' is not registered by any module!`;
 
 export const shouldNeverHappen = (bugLocation: string) =>
   `This should never happen.\nThere is likely a bug in the ${bugLocation}.`;

--- a/libraries/search/lib/objective/ObjectiveFunction.ts
+++ b/libraries/search/lib/objective/ObjectiveFunction.ts
@@ -27,6 +27,7 @@ import { SearchSubject } from "../SearchSubject";
 export abstract class ObjectiveFunction<T extends Encoding> {
   protected _id: string;
   protected _subject: SearchSubject<T>;
+  protected _lowestDistance: number;
 
   /**
    * Indicates if the distance should be shallow or deep.
@@ -43,6 +44,7 @@ export abstract class ObjectiveFunction<T extends Encoding> {
     this._id = id;
     this._subject = subject;
     this.shallowDistance = false;
+    this._lowestDistance = Number.MAX_VALUE;
   }
 
   /**
@@ -80,5 +82,21 @@ export abstract class ObjectiveFunction<T extends Encoding> {
    */
   public getSubject(): SearchSubject<T> {
     return this._subject;
+  }
+
+  /**
+   * Update the lowest distance with a new distance
+   * @param distance
+   */
+  public updateDistance(distance: number) {
+    this._lowestDistance = Math.min(distance, this._lowestDistance);
+  }
+
+  /**
+   * Gets the lowest distance to this objective function
+   * @returns the lowest distance encountered so far
+   */
+  public getLowestDistance(): number {
+    return this._lowestDistance;
   }
 }

--- a/libraries/search/lib/objective/managers/ObjectiveManager.ts
+++ b/libraries/search/lib/objective/managers/ObjectiveManager.ts
@@ -224,6 +224,7 @@ export abstract class ObjectiveManager<T extends Encoding> {
       throw new TypeError(shouldNeverHappen("ObjectiveManager"));
     }
     encoding.setDistance(objectiveFunction, distance);
+    objectiveFunction.updateDistance(distance);
 
     // When the objective is covered, update the objectives and the archive
     if (distance === 0) {

--- a/plugins/plugin-core-event-listener-state-storage/lib/StateStorageEventListenerPlugin.ts
+++ b/plugins/plugin-core-event-listener-state-storage/lib/StateStorageEventListenerPlugin.ts
@@ -19,6 +19,12 @@
 import { Events, RootContext, Target } from "@syntest/analysis";
 import { ControlFlowProgram } from "@syntest/cfg";
 import { EventListenerPlugin } from "@syntest/module";
+import {
+  Encoding,
+  SearchAlgorithm,
+  Events as SearchEvents,
+  SearchSubject,
+} from "@syntest/search";
 import { StorageManager } from "@syntest/storage";
 import TypedEventEmitter from "typed-emitter";
 import Yargs = require("yargs");
@@ -90,6 +96,14 @@ export class StateStorageEventListenerPlugin extends EventListenerPlugin {
           filePath,
           dependencies
         )
+    );
+
+    (<TypedEventEmitter<SearchEvents>>process).on(
+      "searchComplete",
+      <E extends Encoding>(
+        searchAlgorithm: SearchAlgorithm<E>,
+        subject: SearchSubject<E>
+      ) => stateStorage.searchComplete(searchAlgorithm, subject)
     );
   }
 

--- a/plugins/plugin-core-metric-middleware-file-writer/lib/middleware/FileWriterMetricMiddleware.ts
+++ b/plugins/plugin-core-metric-middleware-file-writer/lib/middleware/FileWriterMetricMiddleware.ts
@@ -21,12 +21,17 @@ import * as path from "node:path";
 
 import * as csv from "@fast-csv/format";
 import {
+  Distribution,
   DistributionMetric,
+  DistributionsMap,
   Metric,
   MetricManager,
   MiddleWare,
+  PropertiesMap,
   PropertyMetric,
   SeriesDistributionMetric,
+  SeriesMap,
+  SeriesMeasurementMetric,
   SeriesMetric,
 } from "@syntest/metric";
 import { StorageManager } from "@syntest/storage";
@@ -85,6 +90,14 @@ export class FileWriterMetricMiddleware extends MiddleWare {
         )
       );
 
+      const seriesMeasurements = mergedManager.collectSeriesMeasurements(
+        <SeriesMeasurementMetric[]>(
+          this.outputMetrics.filter(
+            (metric) => metric.type === "series-measurement"
+          )
+        )
+      );
+
       if (properties.size > 0) {
         await this.writePropertiesToCSV(
           this.outputDirectory,
@@ -109,6 +122,13 @@ export class FileWriterMetricMiddleware extends MiddleWare {
           seriesDistributions
         );
       }
+      if (seriesMeasurements.size > 0) {
+        await this.writeSeriesMeasurementToCSV(
+          this.outputDirectory,
+          namespace,
+          seriesMeasurements
+        );
+      }
     }
   }
 
@@ -126,7 +146,7 @@ export class FileWriterMetricMiddleware extends MiddleWare {
   async writePropertiesToCSV(
     filePath: string,
     namespace: string,
-    properties: Map<string, string>
+    properties: PropertiesMap<string>
   ): Promise<void> {
     const fileName = "properties.csv";
     const exists = existsSync(path.join(filePath, fileName));
@@ -159,7 +179,7 @@ export class FileWriterMetricMiddleware extends MiddleWare {
   async writeDistributionsToCSV(
     filePath: string,
     namespace: string,
-    distributions: Map<string, number[]>
+    distributions: DistributionsMap
   ): Promise<void> {
     const fileName = "distributions.csv";
     const exists = existsSync(path.join(filePath, fileName));
@@ -202,7 +222,7 @@ export class FileWriterMetricMiddleware extends MiddleWare {
   async writeSeriesToCSV(
     filePath: string,
     namespace: string,
-    series: Map<string, Map<string, Map<number, number>>>
+    series: SeriesMap<number>
   ): Promise<void> {
     const fileName = "series.csv";
     const exists = existsSync(path.join(filePath, fileName));
@@ -237,7 +257,7 @@ export class FileWriterMetricMiddleware extends MiddleWare {
    * Create one line per value
    *
    * The format is:
-   * namespace,distributionName,seriesName,seriesType,index,value
+   * namespace,name,seriesUnit,index,value
    *
    * @param filePath
    * @param namespace
@@ -247,34 +267,73 @@ export class FileWriterMetricMiddleware extends MiddleWare {
   async writeSeriesDistributionToCSV(
     filePath: string,
     namespace: string,
-    seriesDistributions: Map<
-      string,
-      Map<string, Map<string, Map<number, number[]>>>
-    >
+    seriesDistributions: SeriesMap<Distribution>
   ): Promise<void> {
     const fileName = "series-distributions.csv";
     const exists = existsSync(path.join(filePath, fileName));
 
     const fullData = [];
 
-    for (const [
-      distributionName,
-      distributionData,
-    ] of seriesDistributions.entries()) {
-      for (const [seriesName, seriesNameData] of distributionData.entries()) {
-        for (const [seriesType, seriesTypeData] of seriesNameData.entries()) {
-          for (const [index, value] of seriesTypeData.entries()) {
-            for (const distributionValue of value) {
-              fullData.push({
-                fid: this.fid,
-                namespace: namespace,
-                distributionName: distributionName,
-                seriesName: seriesName,
-                seriesType: seriesType,
-                index: index,
-                value: distributionValue,
-              });
-            }
+    for (const [name, seriesData] of seriesDistributions.entries()) {
+      for (const [seriesUnit, seriesTypeData] of seriesData.entries()) {
+        for (const [index, value] of seriesTypeData.entries()) {
+          for (const distributionValue of value) {
+            fullData.push({
+              fid: this.fid,
+              namespace: namespace,
+              seriesName: name,
+              seriesType: seriesUnit,
+              index: index,
+              value: distributionValue,
+            });
+          }
+        }
+      }
+    }
+
+    const dataAsString = await csv.writeToString(fullData, {
+      headers: !exists,
+      includeEndRowDelimiter: true,
+    });
+
+    this.storageManager.store([filePath], fileName, dataAsString);
+  }
+
+  /**
+   * Creates a CSV file with the series measurements
+   * Create one line per index
+   *
+   * The format is:
+   * namespace,name,seriesUnit,index,key,value
+   *
+   * @param filePath
+   * @param namespace
+   * @param seriesMeasurements
+   */
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+  async writeSeriesMeasurementToCSV(
+    filePath: string,
+    namespace: string,
+    seriesDistributions: SeriesMap<PropertiesMap<number>>
+  ): Promise<void> {
+    const fileName = "series-measurements.csv";
+    const exists = existsSync(path.join(filePath, fileName));
+
+    const fullData = [];
+
+    for (const [name, seriesData] of seriesDistributions.entries()) {
+      for (const [seriesUnit, seriesTypeData] of seriesData.entries()) {
+        for (const [index, map] of seriesTypeData.entries()) {
+          for (const [key, value] of map.entries()) {
+            fullData.push({
+              fid: this.fid,
+              namespace: namespace,
+              seriesName: name,
+              seriesType: seriesUnit,
+              index: index,
+              key: key,
+              value: value,
+            });
           }
         }
       }

--- a/plugins/plugin-core-metric-middleware-statistics/lib/Metrics.ts
+++ b/plugins/plugin-core-metric-middleware-statistics/lib/Metrics.ts
@@ -19,7 +19,7 @@ import { Metric, MetricType } from "@syntest/metric";
 
 const AUC: Metric = {
   type: MetricType.PROPERTY,
-  property: "AUC",
+  name: "AUC",
 };
 
 export const Metrics = {

--- a/plugins/plugin-core-metric-middleware-statistics/lib/middleware/StatisticsMetricMiddleware.ts
+++ b/plugins/plugin-core-metric-middleware-statistics/lib/middleware/StatisticsMetricMiddleware.ts
@@ -50,6 +50,7 @@ export class StatisticsMetricMiddleware extends MiddleWare {
       const series = mergedManager.getAllSeries();
 
       const seriesDistributions = mergedManager.getAllSeriesDistributions();
+      const seriesMeasurements = mergedManager.getAllSeriesMeasurements();
 
       for (const statistic of this.statistics) {
         statistic.generate(
@@ -57,7 +58,8 @@ export class StatisticsMetricMiddleware extends MiddleWare {
           properties,
           distributions,
           series,
-          seriesDistributions
+          seriesDistributions,
+          seriesMeasurements
         );
       }
     }

--- a/plugins/plugin-core-metric-middleware-statistics/lib/plugins/StatisticsMetricMiddlewarePlugin.ts
+++ b/plugins/plugin-core-metric-middleware-statistics/lib/plugins/StatisticsMetricMiddlewarePlugin.ts
@@ -93,7 +93,7 @@ export class StatisticsMetricMiddlewarePlugin extends MetricMiddlewarePlugin {
 
           newMetrics.push({
             type: MetricType.PROPERTY,
-            property: `${statistic}-${metric.seriesName}`,
+            name: `${statistic}-${metric.name}`,
           });
         }
 

--- a/plugins/plugin-core-metric-middleware-statistics/lib/statistics/AUC.ts
+++ b/plugins/plugin-core-metric-middleware-statistics/lib/statistics/AUC.ts
@@ -15,15 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SeriesName } from "@syntest/base-language";
-import { MetricManager, SeriesType } from "@syntest/metric";
 import {
-  Distribution,
-  DistributionName,
-  Property,
-  PropertyName,
-  Series,
-} from "@syntest/metric/lib/PropertyTypes";
+  DistributionsMap,
+  MetricManager,
+  PropertiesMap,
+  SeriesMap,
+} from "@syntest/metric";
+import { Distribution } from "@syntest/metric/lib/PropertyTypes";
 
 import { Statistic } from "./Statistic";
 
@@ -34,13 +32,11 @@ export class AUC extends Statistic {
 
   generate(
     metricManager: MetricManager,
-    _properties: Map<PropertyName, Property>,
-    _distributions: Map<DistributionName, Distribution>,
-    series: Map<SeriesName, Map<SeriesType, Series<number>>>,
-    _seriesDistributions: Map<
-      DistributionName,
-      Map<SeriesName, Map<SeriesType, Series<Distribution>>>
-    >
+    _properties: PropertiesMap<string>,
+    _distributions: DistributionsMap,
+    series: SeriesMap<number>,
+    _seriesDistributions: SeriesMap<Distribution>,
+    _seriesMeasurements: SeriesMap<PropertiesMap<number>>
   ): void {
     this.loopThroughSeries(series, (newPropertyName, seriesByType) => {
       let auc = 0;

--- a/plugins/plugin-core-metric-middleware-statistics/lib/statistics/Statistic.ts
+++ b/plugins/plugin-core-metric-middleware-statistics/lib/statistics/Statistic.ts
@@ -15,15 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { MetricManager } from "@syntest/metric";
+import {
+  DistributionsMap,
+  MetricManager,
+  PropertiesMap,
+  SeriesMap,
+} from "@syntest/metric";
 import {
   Distribution,
-  DistributionName,
-  Property,
-  PropertyName,
   Series,
-  SeriesName,
-  SeriesTyping,
+  SeriesUnit,
 } from "@syntest/metric/lib/PropertyTypes";
 
 export abstract class Statistic {
@@ -35,17 +36,15 @@ export abstract class Statistic {
 
   abstract generate(
     metricManager: MetricManager,
-    properties: Map<PropertyName, Property>,
-    distributions: Map<DistributionName, Distribution>,
-    series: Map<SeriesName, Map<SeriesTyping, Series<number>>>,
-    seriesDistributions: Map<
-      DistributionName,
-      Map<SeriesName, Map<SeriesTyping, Series<Distribution>>>
-    >
+    properties: PropertiesMap<string>,
+    distributions: DistributionsMap,
+    series: SeriesMap<number>,
+    seriesDistributions: SeriesMap<Distribution>,
+    seriesMeasurements: SeriesMap<PropertiesMap<number>>
   ): void;
 
   loopThroughProperties(
-    properties: Map<PropertyName, Property>,
+    properties: PropertiesMap<string>,
     callback: (newPropertyName: string, propertyValue: string) => void
   ) {
     for (const [propertyName, propertyValue] of properties) {
@@ -54,7 +53,7 @@ export abstract class Statistic {
   }
 
   loopThroughDistributions(
-    distributions: Map<DistributionName, Distribution>,
+    distributions: DistributionsMap,
     callback: (newPropertyName: string, distribution: Distribution) => void
   ) {
     for (const [distributionName, distribution] of distributions) {
@@ -63,10 +62,10 @@ export abstract class Statistic {
   }
 
   loopThroughSeries(
-    series: Map<SeriesName, Map<SeriesTyping, Series<number>>>,
+    series: SeriesMap<number>,
     callback: (
       newPropertyName: string,
-      seriesByType: Map<SeriesTyping, Series<number>>
+      seriesByType: Map<SeriesUnit, Series<number>>
     ) => void
   ) {
     for (const [seriesName, seriesByType] of series) {
@@ -75,17 +74,26 @@ export abstract class Statistic {
   }
 
   loopThroughSeriesDistribution(
-    seriesDistributions: Map<
-      DistributionName,
-      Map<SeriesName, Map<SeriesTyping, Series<Distribution>>>
-    >,
+    seriesDistributions: SeriesMap<Distribution>,
     callback: (
       newPropertyName: string,
-      seriesByType: Map<SeriesName, Map<SeriesTyping, Series<Distribution>>>
+      seriesByType: Map<SeriesUnit, Series<Distribution>>
     ) => void
   ) {
     for (const [distributionName, distribution] of seriesDistributions) {
       callback(this.getPropertyName(distributionName), distribution);
+    }
+  }
+
+  loopThroughSeriesMeasurement(
+    seriesMeasurements: SeriesMap<PropertiesMap<number>>,
+    callback: (
+      newPropertyName: string,
+      seriesByType: Map<SeriesUnit, Series<PropertiesMap<number>>>
+    ) => void
+  ) {
+    for (const [name, series] of seriesMeasurements) {
+      callback(this.getPropertyName(name), series);
     }
   }
 

--- a/tools/base-language/lib/Metrics.ts
+++ b/tools/base-language/lib/Metrics.ts
@@ -15,9 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Metric, MetricType, SeriesType } from "@syntest/metric";
+import { Metric, MetricType, SeriesUnit } from "@syntest/metric";
 
 export enum SeriesName {
+  OBJECTIVE_DISTANCE = "objective-distance",
+
   BRANCHES_COVERED = "branches-covered",
   STATEMENTS_COVERED = "statements-covered",
   FUNCTIONS_COVERED = "functions-covered",
@@ -120,506 +122,526 @@ export enum PropertyName {
 }
 
 export const metrics: Metric[] = [
+  {
+    type: MetricType.SERIES_MEASUREMENT,
+    name: SeriesName.OBJECTIVE_DISTANCE,
+    seriesUnit: SeriesUnit.SEARCH_TIME,
+  },
+  {
+    type: MetricType.SERIES_MEASUREMENT,
+    name: SeriesName.OBJECTIVE_DISTANCE,
+    seriesUnit: SeriesUnit.TOTAL_TIME,
+  },
+  {
+    type: MetricType.SERIES_MEASUREMENT,
+    name: SeriesName.OBJECTIVE_DISTANCE,
+    seriesUnit: SeriesUnit.EVALUATION,
+  },
+  {
+    type: MetricType.SERIES_MEASUREMENT,
+    name: SeriesName.OBJECTIVE_DISTANCE,
+    seriesUnit: SeriesUnit.ITERATION,
+  },
   // coverage
   // search time
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.STATEMENTS_COVERED,
-    seriesType: SeriesType.SEARCH_TIME,
+    name: SeriesName.STATEMENTS_COVERED,
+    seriesUnit: SeriesUnit.SEARCH_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.BRANCHES_COVERED,
-    seriesType: SeriesType.SEARCH_TIME,
+    name: SeriesName.BRANCHES_COVERED,
+    seriesUnit: SeriesUnit.SEARCH_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.FUNCTIONS_COVERED,
-    seriesType: SeriesType.SEARCH_TIME,
+    name: SeriesName.FUNCTIONS_COVERED,
+    seriesUnit: SeriesUnit.SEARCH_TIME,
   },
 
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.PATH_OBJECTIVES_COVERED,
-    seriesType: SeriesType.SEARCH_TIME,
+    name: SeriesName.PATH_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.SEARCH_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.BRANCH_OBJECTIVES_COVERED,
-    seriesType: SeriesType.SEARCH_TIME,
+    name: SeriesName.BRANCH_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.SEARCH_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.EXCEPTION_OBJECTIVES_COVERED,
-    seriesType: SeriesType.SEARCH_TIME,
+    name: SeriesName.EXCEPTION_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.SEARCH_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.FUNCTION_OBJECTIVES_COVERED,
-    seriesType: SeriesType.SEARCH_TIME,
+    name: SeriesName.FUNCTION_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.SEARCH_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.LINE_OBJECTIVES_COVERED,
-    seriesType: SeriesType.SEARCH_TIME,
+    name: SeriesName.LINE_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.SEARCH_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.IMPLICIT_BRANCH_OBJECTIVES_COVERED,
-    seriesType: SeriesType.SEARCH_TIME,
+    name: SeriesName.IMPLICIT_BRANCH_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.SEARCH_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.OBJECTIVES_COVERED,
-    seriesType: SeriesType.SEARCH_TIME,
+    name: SeriesName.OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.SEARCH_TIME,
   },
 
   // total time
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.STATEMENTS_COVERED,
-    seriesType: SeriesType.TOTAL_TIME,
+    name: SeriesName.STATEMENTS_COVERED,
+    seriesUnit: SeriesUnit.TOTAL_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.BRANCHES_COVERED,
-    seriesType: SeriesType.TOTAL_TIME,
+    name: SeriesName.BRANCHES_COVERED,
+    seriesUnit: SeriesUnit.TOTAL_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.FUNCTIONS_COVERED,
-    seriesType: SeriesType.TOTAL_TIME,
+    name: SeriesName.FUNCTIONS_COVERED,
+    seriesUnit: SeriesUnit.TOTAL_TIME,
   },
 
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.PATH_OBJECTIVES_COVERED,
-    seriesType: SeriesType.TOTAL_TIME,
+    name: SeriesName.PATH_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.TOTAL_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.BRANCH_OBJECTIVES_COVERED,
-    seriesType: SeriesType.TOTAL_TIME,
+    name: SeriesName.BRANCH_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.TOTAL_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.EXCEPTION_OBJECTIVES_COVERED,
-    seriesType: SeriesType.TOTAL_TIME,
+    name: SeriesName.EXCEPTION_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.TOTAL_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.FUNCTION_OBJECTIVES_COVERED,
-    seriesType: SeriesType.TOTAL_TIME,
+    name: SeriesName.FUNCTION_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.TOTAL_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.LINE_OBJECTIVES_COVERED,
-    seriesType: SeriesType.TOTAL_TIME,
+    name: SeriesName.LINE_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.TOTAL_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.IMPLICIT_BRANCH_OBJECTIVES_COVERED,
-    seriesType: SeriesType.TOTAL_TIME,
+    name: SeriesName.IMPLICIT_BRANCH_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.TOTAL_TIME,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.OBJECTIVES_COVERED,
-    seriesType: SeriesType.TOTAL_TIME,
+    name: SeriesName.OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.TOTAL_TIME,
   },
 
   // iterations
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.STATEMENTS_COVERED,
-    seriesType: SeriesType.ITERATION,
+    name: SeriesName.STATEMENTS_COVERED,
+    seriesUnit: SeriesUnit.ITERATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.BRANCHES_COVERED,
-    seriesType: SeriesType.ITERATION,
+    name: SeriesName.BRANCHES_COVERED,
+    seriesUnit: SeriesUnit.ITERATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.FUNCTIONS_COVERED,
-    seriesType: SeriesType.ITERATION,
+    name: SeriesName.FUNCTIONS_COVERED,
+    seriesUnit: SeriesUnit.ITERATION,
   },
 
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.PATH_OBJECTIVES_COVERED,
-    seriesType: SeriesType.ITERATION,
+    name: SeriesName.PATH_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.ITERATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.BRANCH_OBJECTIVES_COVERED,
-    seriesType: SeriesType.ITERATION,
+    name: SeriesName.BRANCH_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.ITERATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.EXCEPTION_OBJECTIVES_COVERED,
-    seriesType: SeriesType.ITERATION,
+    name: SeriesName.EXCEPTION_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.ITERATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.FUNCTION_OBJECTIVES_COVERED,
-    seriesType: SeriesType.ITERATION,
+    name: SeriesName.FUNCTION_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.ITERATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.LINE_OBJECTIVES_COVERED,
-    seriesType: SeriesType.ITERATION,
+    name: SeriesName.LINE_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.ITERATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.IMPLICIT_BRANCH_OBJECTIVES_COVERED,
-    seriesType: SeriesType.ITERATION,
+    name: SeriesName.IMPLICIT_BRANCH_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.ITERATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.OBJECTIVES_COVERED,
-    seriesType: SeriesType.ITERATION,
+    name: SeriesName.OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.ITERATION,
   },
 
   // evaluations
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.STATEMENTS_COVERED,
-    seriesType: SeriesType.EVALUATION,
+    name: SeriesName.STATEMENTS_COVERED,
+    seriesUnit: SeriesUnit.EVALUATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.BRANCHES_COVERED,
-    seriesType: SeriesType.EVALUATION,
+    name: SeriesName.BRANCHES_COVERED,
+    seriesUnit: SeriesUnit.EVALUATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.FUNCTIONS_COVERED,
-    seriesType: SeriesType.EVALUATION,
+    name: SeriesName.FUNCTIONS_COVERED,
+    seriesUnit: SeriesUnit.EVALUATION,
   },
 
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.PATH_OBJECTIVES_COVERED,
-    seriesType: SeriesType.EVALUATION,
+    name: SeriesName.PATH_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.EVALUATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.BRANCH_OBJECTIVES_COVERED,
-    seriesType: SeriesType.EVALUATION,
+    name: SeriesName.BRANCH_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.EVALUATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.EXCEPTION_OBJECTIVES_COVERED,
-    seriesType: SeriesType.EVALUATION,
+    name: SeriesName.EXCEPTION_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.EVALUATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.FUNCTION_OBJECTIVES_COVERED,
-    seriesType: SeriesType.EVALUATION,
+    name: SeriesName.FUNCTION_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.EVALUATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.LINE_OBJECTIVES_COVERED,
-    seriesType: SeriesType.EVALUATION,
+    name: SeriesName.LINE_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.EVALUATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.IMPLICIT_BRANCH_OBJECTIVES_COVERED,
-    seriesType: SeriesType.EVALUATION,
+    name: SeriesName.IMPLICIT_BRANCH_OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.EVALUATION,
   },
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.OBJECTIVES_COVERED,
-    seriesType: SeriesType.EVALUATION,
+    name: SeriesName.OBJECTIVES_COVERED,
+    seriesUnit: SeriesUnit.EVALUATION,
   },
 
   // totals
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.STATEMENTS_TOTAL,
+    name: PropertyName.STATEMENTS_TOTAL,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.BRANCHES_TOTAL,
+    name: PropertyName.BRANCHES_TOTAL,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.FUNCTIONS_TOTAL,
+    name: PropertyName.FUNCTIONS_TOTAL,
   },
 
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.PATH_OBJECTIVES_TOTAL,
+    name: PropertyName.PATH_OBJECTIVES_TOTAL,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.BRANCH_OBJECTIVES_TOTAL,
+    name: PropertyName.BRANCH_OBJECTIVES_TOTAL,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.FUNCTION_OBJECTIVES_TOTAL,
+    name: PropertyName.FUNCTION_OBJECTIVES_TOTAL,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.EXCEPTION_OBJECTIVES_TOTAL,
+    name: PropertyName.EXCEPTION_OBJECTIVES_TOTAL,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.LINE_OBJECTIVES_TOTAL,
+    name: PropertyName.LINE_OBJECTIVES_TOTAL,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.IMPLICIT_BRANCH_OBJECTIVES_TOTAL,
+    name: PropertyName.IMPLICIT_BRANCH_OBJECTIVES_TOTAL,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.OBJECTIVES_TOTAL,
+    name: PropertyName.OBJECTIVES_TOTAL,
   },
 
   // final coverage
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.STATEMENTS_COVERED,
+    name: PropertyName.STATEMENTS_COVERED,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.BRANCHES_COVERED,
+    name: PropertyName.BRANCHES_COVERED,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.FUNCTIONS_COVERED,
+    name: PropertyName.FUNCTIONS_COVERED,
   },
 
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.PATH_OBJECTIVES_COVERED,
+    name: PropertyName.PATH_OBJECTIVES_COVERED,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.BRANCH_OBJECTIVES_COVERED,
+    name: PropertyName.BRANCH_OBJECTIVES_COVERED,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.FUNCTION_OBJECTIVES_COVERED,
+    name: PropertyName.FUNCTION_OBJECTIVES_COVERED,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.EXCEPTION_OBJECTIVES_COVERED,
+    name: PropertyName.EXCEPTION_OBJECTIVES_COVERED,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.LINE_OBJECTIVES_COVERED,
+    name: PropertyName.LINE_OBJECTIVES_COVERED,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.IMPLICIT_BRANCH_OBJECTIVES_COVERED,
+    name: PropertyName.IMPLICIT_BRANCH_OBJECTIVES_COVERED,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.OBJECTIVES_COVERED,
+    name: PropertyName.OBJECTIVES_COVERED,
   },
 
   // general properties
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.PRESET,
+    name: PropertyName.PRESET,
   },
 
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.TARGET_ROOT_DIRECTORY,
+    name: PropertyName.TARGET_ROOT_DIRECTORY,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.INCLUDE,
+    name: PropertyName.INCLUDE,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.EXCLUDE,
+    name: PropertyName.EXCLUDE,
   },
 
   // search
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.SEARCH_ALGORITHM,
+    name: PropertyName.SEARCH_ALGORITHM,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.POPULATION_SIZE,
+    name: PropertyName.POPULATION_SIZE,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.OBJECTIVE_MANAGER,
+    name: PropertyName.OBJECTIVE_MANAGER,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.SECONDARY_OBJECTIVES,
+    name: PropertyName.SECONDARY_OBJECTIVES,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.PROCREATION,
+    name: PropertyName.PROCREATION,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.CROSSOVER,
+    name: PropertyName.CROSSOVER,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.SAMPLER,
+    name: PropertyName.SAMPLER,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.TERMINATION_TRIGGERS,
+    name: PropertyName.TERMINATION_TRIGGERS,
   },
 
   // timing
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.MAX_TOTAL_TIME,
+    name: PropertyName.MAX_TOTAL_TIME,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.MAX_SEARCH_TIME,
+    name: PropertyName.MAX_SEARCH_TIME,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.MAX_EVALUATIONS,
+    name: PropertyName.MAX_EVALUATIONS,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.MAX_ITERATIONS,
+    name: PropertyName.MAX_ITERATIONS,
   },
   // postprocess
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.TEST_MINIMIZATION,
+    name: PropertyName.TEST_MINIMIZATION,
   },
   // sampling
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.RANDOM_SEED,
+    name: PropertyName.RANDOM_SEED,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.MAX_DEPTH,
+    name: PropertyName.MAX_DEPTH,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.MAX_ACTION_STATEMENTS,
+    name: PropertyName.MAX_ACTION_STATEMENTS,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.CONSTANT_POOL_ENABLED,
+    name: PropertyName.CONSTANT_POOL_ENABLED,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.EXPLORE_ILLEGAL_VALUES,
+    name: PropertyName.EXPLORE_ILLEGAL_VALUES,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.RESAMPLE_GENE_PROBABILITY,
+    name: PropertyName.RESAMPLE_GENE_PROBABILITY,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.DELTA_MUTATION_PROBABILITY,
+    name: PropertyName.DELTA_MUTATION_PROBABILITY,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.SAMPLE_EXISTING_VALUE_PROBABILITY,
+    name: PropertyName.SAMPLE_EXISTING_VALUE_PROBABILITY,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.MULTI_POINT_CROSSOVER_PROBABILITY,
+    name: PropertyName.MULTI_POINT_CROSSOVER_PROBABILITY,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.CROSSOVER_PROBABILITY,
+    name: PropertyName.CROSSOVER_PROBABILITY,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.CONSTANT_POOL_PROBABILITY,
+    name: PropertyName.CONSTANT_POOL_PROBABILITY,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.SAMPLE_FUNCTION_OUTPUT_AS_ARGUMENT,
+    name: PropertyName.SAMPLE_FUNCTION_OUTPUT_AS_ARGUMENT,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.STRING_ALPHABET,
+    name: PropertyName.STRING_ALPHABET,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.STRING_MAX_LENGTH,
+    name: PropertyName.STRING_MAX_LENGTH,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.NUMERIC_MAX_VALUE,
+    name: PropertyName.NUMERIC_MAX_VALUE,
   },
 
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.CONFIGURATION,
+    name: PropertyName.CONFIGURATION,
   },
 
   // Timing
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.TOTAL_TIME,
+    name: PropertyName.TOTAL_TIME,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.SEARCH_TIME,
+    name: PropertyName.SEARCH_TIME,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.EVALUATIONS,
+    name: PropertyName.EVALUATIONS,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.ITERATIONS,
+    name: PropertyName.ITERATIONS,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.INITIALIZATION_TIME,
+    name: PropertyName.INITIALIZATION_TIME,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.PREPROCESS_TIME,
+    name: PropertyName.PREPROCESS_TIME,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.PROCESS_TIME,
+    name: PropertyName.PROCESS_TIME,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.POSTPROCESS_TIME,
+    name: PropertyName.POSTPROCESS_TIME,
   },
 
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.TARGET_LOAD_TIME,
+    name: PropertyName.TARGET_LOAD_TIME,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.INSTRUMENTATION_TIME,
+    name: PropertyName.INSTRUMENTATION_TIME,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.TYPE_RESOLVE_TIME,
+    name: PropertyName.TYPE_RESOLVE_TIME,
   },
 
   // Archive
   {
     type: MetricType.SERIES,
-    seriesName: SeriesName.ARCHIVE_SIZE,
-    seriesType: SeriesType.TOTAL_TIME,
+    name: SeriesName.ARCHIVE_SIZE,
+    seriesUnit: SeriesUnit.TOTAL_TIME,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.ARCHIVE_SIZE,
+    name: PropertyName.ARCHIVE_SIZE,
   },
   {
     type: MetricType.PROPERTY,
-    property: PropertyName.MINIMIZED_ARCHIVE_SIZE,
+    name: PropertyName.MINIMIZED_ARCHIVE_SIZE,
   },
 ];

--- a/tools/base-language/lib/plugins/event-listeners/SearchMetricListener.ts
+++ b/tools/base-language/lib/plugins/event-listeners/SearchMetricListener.ts
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Metric, MetricManager, SeriesType } from "@syntest/metric";
+import { Metric, MetricManager, SeriesUnit } from "@syntest/metric";
 import { EventListenerPlugin } from "@syntest/module";
 import {
   BranchObjectiveFunction,
@@ -26,6 +26,7 @@ import {
   ExceptionObjectiveFunction,
   FunctionObjectiveFunction,
   ImplicitBranchObjectiveFunction,
+  ObjectiveFunction,
   SearchAlgorithm,
   SearchSubject,
 } from "@syntest/search";
@@ -87,6 +88,10 @@ export class SearchMetricListener extends EventListenerPlugin {
       ...searchAlgorithm.getObjectiveManager().getCoveredObjectives(),
     ];
 
+    const uncovered = [
+      ...searchAlgorithm.getObjectiveManager().getUncoveredObjectives(),
+    ];
+
     const coveredPaths = 0;
     const coveredBranches = covered.filter(
       (objectiveFunction) =>
@@ -109,7 +114,7 @@ export class SearchMetricListener extends EventListenerPlugin {
 
     // search times
     this.recordCoveredSeries(
-      SeriesType.SEARCH_TIME,
+      SeriesUnit.SEARCH_TIME,
       searchTime,
       coveredPaths,
       coveredBranches,
@@ -117,10 +122,12 @@ export class SearchMetricListener extends EventListenerPlugin {
       coveredLines,
       coveredImplicitBranches,
       coveredObjectives,
-      coveredExceptions
+      coveredExceptions,
+      covered,
+      uncovered
     );
     this.recordCoveredSeries(
-      SeriesType.TOTAL_TIME,
+      SeriesUnit.TOTAL_TIME,
       totalTime,
       coveredPaths,
       coveredBranches,
@@ -128,10 +135,12 @@ export class SearchMetricListener extends EventListenerPlugin {
       coveredLines,
       coveredImplicitBranches,
       coveredObjectives,
-      coveredExceptions
+      coveredExceptions,
+      covered,
+      uncovered
     );
     this.recordCoveredSeries(
-      SeriesType.ITERATION,
+      SeriesUnit.ITERATION,
       iterations,
       coveredPaths,
       coveredBranches,
@@ -139,10 +148,12 @@ export class SearchMetricListener extends EventListenerPlugin {
       coveredLines,
       coveredImplicitBranches,
       coveredObjectives,
-      coveredExceptions
+      coveredExceptions,
+      covered,
+      uncovered
     );
     this.recordCoveredSeries(
-      SeriesType.EVALUATION,
+      SeriesUnit.EVALUATION,
       evaluations,
       coveredPaths,
       coveredBranches,
@@ -150,12 +161,14 @@ export class SearchMetricListener extends EventListenerPlugin {
       coveredLines,
       coveredImplicitBranches,
       coveredObjectives,
-      coveredExceptions
+      coveredExceptions,
+      covered,
+      uncovered
     );
   }
 
-  recordCoveredSeries(
-    type: string,
+  recordCoveredSeries<E extends Encoding>(
+    type: SeriesUnit,
     index: number,
     coveredPaths: number,
     coveredBranches: number,
@@ -163,8 +176,30 @@ export class SearchMetricListener extends EventListenerPlugin {
     coveredLines: number,
     coveredImplicitBranches: number,
     covered: number,
-    coveredExceptions: number
+    coveredExceptions: number,
+    coveredObjectives: ObjectiveFunction<E>[],
+    uncoveredObjectives: ObjectiveFunction<E>[]
   ) {
+    for (const objective of coveredObjectives) {
+      this.metricManager.recordSeriesMeasurement(
+        SeriesName.OBJECTIVE_DISTANCE,
+        type,
+        index,
+        objective.getIdentifier(),
+        objective.getLowestDistance()
+      );
+    }
+
+    for (const objective of uncoveredObjectives) {
+      this.metricManager.recordSeriesMeasurement(
+        SeriesName.OBJECTIVE_DISTANCE,
+        type,
+        index,
+        objective.getIdentifier(),
+        objective.getLowestDistance()
+      );
+    }
+
     this.metricManager.recordSeries(
       SeriesName.PATH_OBJECTIVES_COVERED,
       type,


### PR DESCRIPTION
Implements a way to:
- store the final covered and uncovered objectives to file.
- store the distance to each objective per timestep to the metric manager.

Renamed:
- seriesName -> name
- seriesType -> seriesUnit
- distributionName -> name
- property -> name

Added metric type: "series measurement"