### PR TITLE
Duplicate search namespaces

### DIFF
--- a/tools/base-language/lib/plugins/event-listeners/SearchMetricListener.ts
+++ b/tools/base-language/lib/plugins/event-listeners/SearchMetricListener.ts
@@ -339,7 +339,7 @@ export class SearchMetricListener extends EventListenerPlugin {
         budgetManager: BudgetManager<E>
       ) => {
         // create a new metric manager for this search subject
-        this.currentNamespace = subject.name;
+        this.currentNamespace = subject.path;
 
         this.recordSeries(searchAlgorithm, subject, budgetManager);
       }


### PR DESCRIPTION
Currently, the namespaces are set to the subject name (i.e., name of the file), however, when two files have the same name, this means these files are put together when processing the files.