### PR TITLE
Refactor execution results

### DIFF
--- a/libraries/search/index.ts
+++ b/libraries/search/index.ts
@@ -87,6 +87,6 @@ export * from "./lib/termination/TerminationManager";
 export * from "./lib/termination/TerminationTrigger";
 
 // Util
-export * from "./lib/util/Datapoint";
+export * from "./lib/Trace";
 export * from "./lib/util/diagnostics";
 export * from "./lib/util/Events";

--- a/libraries/search/lib/ExecutionResult.ts
+++ b/libraries/search/lib/ExecutionResult.ts
@@ -16,12 +16,10 @@
  * limitations under the License.
  */
 
-import { Datapoint } from "./util/Datapoint";
+import { Trace } from "./Trace";
 
 /**
  * Results of an execution by the runner.
- *
- * @author Mitchell Olsthoorn
  */
 export interface ExecutionResult {
   /**
@@ -37,19 +35,19 @@ export interface ExecutionResult {
   getDuration(): number;
 
   /**
-   * Return all exceptions that occurred during the execution.
+   * Return error that occurred during the execution.
    */
-  getExceptions(): string;
+  getError(): Error;
 
   /**
    * Return all the traces produced by the execution.
    */
-  getTraces(): Datapoint[];
+  getTraces(): Trace[];
 
   /**
-   * Return if any exceptions occurred during the execution.
+   * Return if an error occurred during the execution.
    */
-  hasExceptions(): boolean;
+  hasError(): boolean;
 
   /**
    * Return if the execution has passed.

--- a/libraries/search/lib/Trace.ts
+++ b/libraries/search/lib/Trace.ts
@@ -19,9 +19,9 @@
 import { Location } from "@syntest/cfg";
 
 /**
- * @author Dimitri Stallenberg
+ * Execution trace
  */
-export interface Datapoint {
+export interface Trace {
   id: string;
   type: string;
 
@@ -30,7 +30,6 @@ export interface Datapoint {
 
   hits: number;
 
-  condition_ast?: string;
   condition?: string;
   variables?: unknown;
 }

--- a/libraries/search/lib/objective/BranchObjectiveFunction.ts
+++ b/libraries/search/lib/objective/BranchObjectiveFunction.ts
@@ -196,7 +196,6 @@ export class BranchObjectiveFunction<
     }
 
     let branchDistance = this.branchDistance.calculate(
-      trace.condition_ast,
       trace.condition,
       trace.variables,
       lastEdgeType

--- a/libraries/search/lib/objective/ExceptionObjectiveFunction.ts
+++ b/libraries/search/lib/objective/ExceptionObjectiveFunction.ts
@@ -32,11 +32,11 @@ import { shouldNeverHappen } from "../util/diagnostics";
 export class ExceptionObjectiveFunction<
   T extends Encoding
 > extends ObjectiveFunction<T> {
-  protected _message: string;
+  protected _error: Error;
 
-  constructor(subject: SearchSubject<T>, id: string, message: string) {
+  constructor(subject: SearchSubject<T>, id: string, error: Error) {
     super(id, subject);
-    this._message = message;
+    this._error = error;
   }
 
   /**

--- a/libraries/search/lib/objective/ExceptionObjectiveFunction.ts
+++ b/libraries/search/lib/objective/ExceptionObjectiveFunction.ts
@@ -39,6 +39,10 @@ export class ExceptionObjectiveFunction<
     this._error = error;
   }
 
+  get error() {
+    return this._error;
+  }
+
   /**
    * @inheritDoc
    */

--- a/libraries/search/lib/objective/heuristics/ApproachLevel.ts
+++ b/libraries/search/lib/objective/heuristics/ApproachLevel.ts
@@ -17,23 +17,23 @@
  */
 import { ControlFlowGraph, EdgeType, Node } from "@syntest/cfg";
 
-import { Datapoint } from "../../util/Datapoint";
+import { Trace } from "../../Trace";
 import { cannotFindTraceThatIsCovered } from "../../util/diagnostics";
 
 export class ApproachLevel {
   public calculate(
     cfg: ControlFlowGraph,
     node: Node,
-    traces: Datapoint[]
+    traces: Trace[]
   ): {
     approachLevel: number;
     closestCoveredNode: Node;
-    closestCoveredBranchTrace: Datapoint;
+    closestCoveredBranchTrace: Trace;
     lastEdgeType: boolean;
     statementFraction: number;
   } {
     // Construct map with key as id covered and value as datapoint that covers that id
-    const idsTraceMap: Map<string, Datapoint> = new Map(
+    const idsTraceMap: Map<string, Trace> = new Map(
       traces.filter((trace) => trace.hits > 0).map((trace) => [trace.id, trace])
     );
 

--- a/libraries/search/lib/objective/heuristics/BranchDistance.ts
+++ b/libraries/search/lib/objective/heuristics/BranchDistance.ts
@@ -23,7 +23,6 @@ export abstract class BranchDistance {
    * @param node
    */
   public abstract calculate(
-    conditionAST: string,
     condition: string,
     variables: unknown,
     trueOrFalse: boolean

--- a/libraries/search/lib/objective/managers/ArchiveBasedObjectiveManager.ts
+++ b/libraries/search/lib/objective/managers/ArchiveBasedObjectiveManager.ts
@@ -17,6 +17,7 @@
  */
 
 import { Encoding } from "../../Encoding";
+import { ExceptionObjectiveFunction } from "../ExceptionObjectiveFunction";
 import { ObjectiveFunction } from "../ObjectiveFunction";
 
 import { ObjectiveManager } from "./ObjectiveManager";
@@ -65,9 +66,17 @@ export abstract class ArchiveBasedObjectiveManager<
     for (const encoding of encodings) {
       const uses = this._archive.getUses(encoding);
       for (const use of uses) {
-        encoding.addMetaComment(
-          `Selected for objective: ${use.getIdentifier()}`
-        );
+        if (use instanceof ExceptionObjectiveFunction) {
+          encoding.addMetaComment(`Selected for:`);
+          for (const line of use.error.stack.split("\n")) {
+            encoding.addMetaComment(`\t${line}`);
+          }
+          encoding.addMetaComment("");
+        } else {
+          encoding.addMetaComment(
+            `Selected for objective: ${use.getIdentifier()}`
+          );
+        }
       }
 
       const executionResult = encoding.getExecutionResult();

--- a/libraries/search/lib/objective/managers/ObjectiveManager.ts
+++ b/libraries/search/lib/objective/managers/ObjectiveManager.ts
@@ -186,13 +186,10 @@ export abstract class ObjectiveManager<T extends Encoding> {
     }
 
     // Create separate exception objective when an exception occurred in the execution
-    if (result.hasExceptions()) {
-      // TODO there must be a better way
-      //  investigate error patterns somehow
-
+    if (result.hasError()) {
       const hash = crypto
         .createHash("md5")
-        .update(result.getExceptions())
+        .update(result.getError().stack)
         .digest("hex");
 
       const numberOfExceptions = this._archive
@@ -200,12 +197,11 @@ export abstract class ObjectiveManager<T extends Encoding> {
         .filter((objective) => objective instanceof ExceptionObjectiveFunction)
         .filter((objective) => objective.getIdentifier() === hash).length;
       if (numberOfExceptions === 0) {
-        // TODO this makes the archive become too large crashing the tool
         this._archive.update(
           new ExceptionObjectiveFunction(
             this._subject,
             hash,
-            result.getExceptions()
+            result.getError()
           ),
           encoding,
           false

--- a/libraries/search/lib/objective/managers/ObjectiveManager.ts
+++ b/libraries/search/lib/objective/managers/ObjectiveManager.ts
@@ -192,7 +192,10 @@ export abstract class ObjectiveManager<T extends Encoding> {
       stack = stack
         ? stack
             .split("\n")
+            // only use location lines
             .filter((line) => line.startsWith("    at"))
+            // only use locations within the source code (i.e. not from the generated tests)
+            .filter((line) => line.includes("/instrumented/")) // stupid hack should be done better somehow, suffices for now
             .join("\n")
         : result.getError().message;
 

--- a/libraries/search/lib/objective/managers/ObjectiveManager.ts
+++ b/libraries/search/lib/objective/managers/ObjectiveManager.ts
@@ -187,10 +187,16 @@ export abstract class ObjectiveManager<T extends Encoding> {
 
     // Create separate exception objective when an exception occurred in the execution
     if (result.hasError()) {
-      const hash = crypto
-        .createHash("md5")
-        .update(result.getError().stack ?? result.getError().message)
-        .digest("hex");
+      let stack = result.getError().stack;
+
+      stack = stack
+        ? stack
+            .split("\n")
+            .filter((line) => line.startsWith("    at"))
+            .join("\n")
+        : result.getError().message;
+
+      const hash = crypto.createHash("md5").update(stack).digest("hex");
 
       const numberOfExceptions = this._archive
         .getObjectives()

--- a/libraries/search/lib/objective/managers/ObjectiveManager.ts
+++ b/libraries/search/lib/objective/managers/ObjectiveManager.ts
@@ -189,7 +189,7 @@ export abstract class ObjectiveManager<T extends Encoding> {
     if (result.hasError()) {
       const hash = crypto
         .createHash("md5")
-        .update(result.getError().stack)
+        .update(result.getError().stack ?? result.getError().message)
         .digest("hex");
 
       const numberOfExceptions = this._archive

--- a/libraries/search/lib/objective/managers/PopulationBasedObjectiveManager.ts
+++ b/libraries/search/lib/objective/managers/PopulationBasedObjectiveManager.ts
@@ -17,6 +17,7 @@
  */
 
 import { Encoding } from "../../Encoding";
+import { ExceptionObjectiveFunction } from "../ExceptionObjectiveFunction";
 import { ObjectiveFunction } from "../ObjectiveFunction";
 
 import { ObjectiveManager } from "./ObjectiveManager";
@@ -82,9 +83,17 @@ export abstract class PopulationBasedObjectiveManager<
     for (const encoding of encodings) {
       const uses = this._archive.getUses(encoding);
       for (const use of uses) {
-        encoding.addMetaComment(
-          `Selected for objective: ${use.getIdentifier()}`
-        );
+        if (use instanceof ExceptionObjectiveFunction) {
+          encoding.addMetaComment(`Selected for:`);
+          for (const line of use.error.stack.split("\n")) {
+            encoding.addMetaComment(`\t${line}`);
+          }
+          encoding.addMetaComment("");
+        } else {
+          encoding.addMetaComment(
+            `Selected for objective: ${use.getIdentifier()}`
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
* Rename Datapoint -> Trace
* In ExecutionResult: getException -> getError (actually returns an error object instead of string)
* In ExecutionResult: hasException -> hasException
* Removes condition_ast from traces
* Uses the stacktrace to generate exception hashes